### PR TITLE
Update RBAC apiVersion from v1beta1 to v1

### DIFF
--- a/easyK8s-aws.sh
+++ b/easyK8s-aws.sh
@@ -134,7 +134,7 @@ metadata:
   name: percona-dbaas-cluster-operator
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-percona-server-dbaas-xtradb-operator
 subjects:
@@ -146,7 +146,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-percona-server-dbaas-psmdb-operator
 subjects:
@@ -157,7 +157,7 @@ roleRef:
   name: percona-server-mongodb-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: service-account-percona-server-dbaas-admin
@@ -166,7 +166,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: service-account-percona-server-dbaas-operator-admin


### PR DESCRIPTION
RBAC resources 
The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.

htttps://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

I tested this script with `v1` and it worked perfectly. It will great to update it! 

@shoffman-percona please, let me know if this sounds good to you. Thanks in advance!